### PR TITLE
padroniza os nomes de colunas entre as bases

### DIFF
--- a/schemas/base_categoria_pessoal.yaml
+++ b/schemas/base_categoria_pessoal.yaml
@@ -1,7 +1,9 @@
 fields:
   - name: Ano de Exercício
+    target: ANO
     type: integer
   - name: UO
+    target: UO_COD
     type: string
   - name: Classificação
     type: string

--- a/schemas/base_detalhamento_obras.yaml
+++ b/schemas/base_detalhamento_obras.yaml
@@ -1,17 +1,24 @@
 fields:
   - name: UO
+    target: UO_COD
     type: integer
   - name: FUNCAO
+    target: FUNCAO_COD
     type: integer
   - name: SUBFUNCAO
+    target: SUBFUNCAO_COD
     type: integer
   - name: PROGRAMA
+    target: PROGRAMA_COD
     type: integer
   - name: ACAO
+    target: ACAO_COD
     type: integer
   - name: SUBPROJETO
+    target: SUBPROJETO_COD
     type: integer
   - name: IAG
+    target: IAG_COD
     type: integer
   - name: NUMERO DA OBRA SISOR
     type: integer

--- a/schemas/base_limite_cota.yaml
+++ b/schemas/base_limite_cota.yaml
@@ -1,15 +1,20 @@
 fields:
   - name: Cód. UO
+    target: UO_COD
     type: integer
   - name: UO
     type: string
   - name: Grupo de Despesa
+    target: GRUPO_COD
     type: integer
   - name: Fonte
+    target: FONTE_COD
     type: integer
   - name: IPU
+    target: IPU_COD
     type: integer
   - name: IAG
+    target: IAG_COD
     type: integer
   - name: Valor Limite 2024
     type: number

--- a/schemas/base_orcam_despesa_investimento.yaml
+++ b/schemas/base_orcam_despesa_investimento.yaml
@@ -1,35 +1,50 @@
 fields:
   - name: Código do Órgão
+    target: ORGAO_COD
     type: integer
   - name: Órgão
+    target: ORGAO_NOME_SIGLA
     type: string
   - name: Código da UO
+    target: UO_COD
     type: integer
   - name: Unidade Orçamentária
+    target: UO_NOME_SIGLA
     type: string
   - name: Função
+    target: FUNCAO_COD
     type: integer
   - name: Subfunção
+    target: SUBFUNCAO_COD 
     type: integer
   - name: Programa
+    target: PROGRAMA_COD
     type: integer
   - name: Identificador
+    target: IDENTIFICADOR
     type: integer
   - name: Projeto_Atividade
+    target: PROJETO_ATIVIDADE
     type: integer
   - name: Ação
+    target: ACAO_COD
     type: integer
   - name: Subprojeto
+    target: SUBPROJETO_COD
     type: integer
   - name: Fonte
+    target: FONTE_COD
     type: integer
   - name: IAG
+    target: IAG_COD
     type: integer
   - name: Descrição
     type: string
   - name: Categoria
+    target: CATEGORIA_COD
     type: string
   - name: Código da Natureza
+    target: NATUREZA_COD
     type: integer
   - name: Natureza
     type: string

--- a/schemas/base_orcam_receita_investimento.yaml
+++ b/schemas/base_orcam_receita_investimento.yaml
@@ -1,9 +1,12 @@
 fields:
   - name: COD_UO
+    target: UO_COD
     type: integer
   - name: NOME_UO
+    target: UO_NOME
     type: string
   - name: SIGLA_UO
+    target: UO_SIGLA
     type: string
   - name: CATEGORIA
     type: integer

--- a/schemas/base_qdd_investimento.yaml
+++ b/schemas/base_qdd_investimento.yaml
@@ -2,48 +2,63 @@ fields:
   - name: ANO
     type: integer
   - name: COD_ORGAO
+    target: ORGAO_COD
     type: integer
   - name: ORGAO
+    target: ORGAO_NOME_SIGLA
     type: string
   - name: PODER
+    target: PODER_COD
     type: integer
   - name: COD_UO
+    target: UO_COD
     type: integer
   - name: UO
+    target: UO_NOME_SIGLA
     type: string
   - name: SEQ_PROGTRAB
     type: integer
   - name: FUNCAO
+    target: FUNCAO_COD
     type: integer
   - name: SUB_FUNCAO
+    target: SUBFUNCAO_COD
     type: integer
   - name: PROGRAMA
+    target: PROGRAMA_COD
     type: integer
   - name: IDENT_PROJATIV
     type: integer
   - name: PROJ_ATIV
     type: integer
   - name: AÇÃO
+    target: ACAO_COD
     type: integer
   - name: VALOR (R$)
     type: number
     groupChar: '.'
     decimalChar: ','
   - name: IAG
+    target: IAG_COD
     type: integer
   - name: DESC_PROJETO_ATIV
     type: string
   - name: CATEGORIA
+    target: CATEGORIA_COD
     type: string
   - name: COD_NATUREZA
+    target: NATUREZA_COD
     type: integer
   - name: NATUREZA
     type: string
   - name: COD_FONTE
+    target: FONTE_COD
     type: integer
   - name: FONTE
     type: string
   - name: NOME_ACAO
+    target: ACAO_DESC
     type: string
   - name: NOME_PROGRAMA
+    target: PROGRAMA_DESC
     type: string


### PR DESCRIPTION
cria `target` nos datapackages onde não exista para padronizar nomes das colunas entre bases, em acordo com o pacote `execucao` da DCAF.